### PR TITLE
Add box-sizing and font-family to all base HTML elements used

### DIFF
--- a/packages/hs-react-ui/.storybook/preview-body.html
+++ b/packages/hs-react-ui/.storybook/preview-body.html
@@ -7,7 +7,6 @@
     height: 100%;
   }
   #root {
-    height: 100%;
     display: flex;
     flex-flow: column nowrap;
     justify-content: center;

--- a/packages/hs-react-ui/src/boilerplate/index.tsx
+++ b/packages/hs-react-ui/src/boilerplate/index.tsx
@@ -1,0 +1,18 @@
+import fonts from '../enums/fonts';
+import styled from 'styled-components';
+
+const withGlobalStyle = Component => styled(Component)`
+  box-sizing: border-box;
+  ${fonts.body}
+`;
+
+export const Div = withGlobalStyle(styled.div``);
+export const Span = withGlobalStyle(styled.span``);
+export const Button = withGlobalStyle(styled.button``);
+export const Input = withGlobalStyle(styled.input``);
+export const Label = withGlobalStyle(styled.label``);
+export const HR = withGlobalStyle(styled.hr``);
+export const Table = withGlobalStyle(styled.table``);
+export const TH = withGlobalStyle(styled.th``);
+export const TD = withGlobalStyle(styled.td``);
+export const TR = withGlobalStyle(styled.tr``);

--- a/packages/hs-react-ui/src/components/Button/Button.tsx
+++ b/packages/hs-react-ui/src/components/Button/Button.tsx
@@ -5,9 +5,9 @@ import styled, { StyledComponentBase } from 'styled-components';
 import { readableColor, darken } from 'polished';
 
 import timings from '../../enums/timings';
-import fonts from '../../enums/fonts';
 import colors from '../../enums/colors';
 import Progress from '../Progress/Progress';
+import { Span, Button as ButtonElement } from '../../boilerplate';
 
 export type ButtonContainerProps = {
   elevation?: number;
@@ -68,8 +68,9 @@ export const getBackgroundColorFromType = (type: string, color?: string) => {
   }
 };
 
-export const ButtonContainer: string &
-  StyledComponentBase<any, {}, ButtonContainerProps> = styled.button`
+export const ButtonContainer: string & StyledComponentBase<any, {}, ButtonContainerProps> = styled(
+  ButtonElement,
+)`
   ${({ elevation = 0, color, type }: ButtonContainerProps) => {
     const backgroundColor = getBackgroundColorFromType(type, color);
     const fontColor = getFontColorFromType(type, color);
@@ -79,7 +80,6 @@ export const ButtonContainer: string &
 
     return `
       display: inline-block;
-      ${fonts.body}
       font-size: 1em;
       padding: .75em 1em;
       border-radius: 0.25em;
@@ -111,7 +111,7 @@ const StyledProgress = styled(Progress)`
   margin-bottom: -5px;
 `;
 
-const IconContainer = styled.span`
+const IconContainer = styled(Span)`
   margin-top: -8px;
   margin-bottom: -8px;
 `;

--- a/packages/hs-react-ui/src/components/Button/Button.tsx
+++ b/packages/hs-react-ui/src/components/Button/Button.tsx
@@ -7,7 +7,7 @@ import { readableColor, darken } from 'polished';
 import timings from '../../enums/timings';
 import colors from '../../enums/colors';
 import Progress from '../Progress/Progress';
-import { Span, Button as ButtonElement } from '../../boilerplate';
+import { Span, Button as ButtonElement } from '../../htmlElements';
 
 export type ButtonContainerProps = {
   elevation?: number;

--- a/packages/hs-react-ui/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/hs-react-ui/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Button keeps the container the same when switching between isLoading and not isLoading 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -27,7 +27,7 @@ exports[`Button keeps the container the same when switching between isLoading an
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   background: linear-gradient( 45deg, rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75) ) repeat;
@@ -58,7 +58,7 @@ exports[`Button keeps the container the same when switching between isLoading an
 `;
 
 exports[`Button keeps the container the same when switching between isLoading and not isLoading 2`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -96,7 +96,7 @@ exports[`Button keeps the container the same when switching between isLoading an
 `;
 
 exports[`Button shows loading text when provided 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -122,7 +122,7 @@ exports[`Button shows loading text when provided 1`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   background: linear-gradient( 45deg, rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75) ) repeat;

--- a/packages/hs-react-ui/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
+++ b/packages/hs-react-ui/src/components/Button/__tests__/__snapshots__/Button.test.tsx.snap
@@ -2,8 +2,9 @@
 
 exports[`Button keeps the container the same when switching between isLoading and not isLoading 1`] = `
 500;700;900&display=swap'); .c0 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -26,7 +27,9 @@ exports[`Button keeps the container the same when switching between isLoading an
   background-color: #101317;
 }
 
-.c1 {
+500;700;900&display=swap'); .c1 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   background: linear-gradient( 45deg, rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75) ) repeat;
   background-size: 400% 100%;
   width: 6rem;
@@ -42,22 +45,23 @@ exports[`Button keeps the container the same when switching between isLoading an
 }
 
 <button
-  class="c0"
+  class="sc-AxhUy sc-AxgMl c0"
   color="#252c35"
   data-test-id="hsui-button"
   elevation="0"
   type="fill"
 >
   <div
-    class="sc-AxjAm c1"
+    class="sc-AxjAm sc-AxirZ sc-fzoLag c1"
   />
 </button>
 `;
 
 exports[`Button keeps the container the same when switching between isLoading and not isLoading 2`] = `
 500;700;900&display=swap'); .c0 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -81,7 +85,7 @@ exports[`Button keeps the container the same when switching between isLoading an
 }
 
 <button
-  class="c0"
+  class="sc-AxhUy sc-AxgMl c0"
   color="#252c35"
   data-test-id="hsui-button"
   elevation="0"
@@ -93,8 +97,9 @@ exports[`Button keeps the container the same when switching between isLoading an
 
 exports[`Button shows loading text when provided 1`] = `
 500;700;900&display=swap'); .c0 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -117,7 +122,9 @@ exports[`Button shows loading text when provided 1`] = `
   background-color: #101317;
 }
 
-.c1 {
+500;700;900&display=swap'); .c1 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   background: linear-gradient( 45deg, rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75), rgba(0,0,0,0.75), rgba(255,255,255,0.75) ) repeat;
   background-size: 400% 100%;
   width: 6rem;
@@ -134,14 +141,14 @@ exports[`Button shows loading text when provided 1`] = `
 
 <div>
   <button
-    class="c0"
+    class="sc-AxhUy sc-AxgMl c0"
     color="#252c35"
     data-test-id="hsui-button"
     elevation="0"
     type="fill"
   >
     <div
-      class="sc-AxjAm c1"
+      class="sc-AxjAm sc-AxirZ sc-fzoLag c1"
     />
   </button>
 </div>

--- a/packages/hs-react-ui/src/components/Card/Card.tsx
+++ b/packages/hs-react-ui/src/components/Card/Card.tsx
@@ -3,7 +3,7 @@ import styled, { StyledComponentBase } from 'styled-components';
 
 import colors from '../../enums/colors';
 import timings from '../../enums/timings';
-import { Div } from '../../boilerplate';
+import { Div } from '../../htmlElements';
 
 export const CardContainer = styled(Div)`
   ${({ elevation = 0 }: { elevation: number }) => `

--- a/packages/hs-react-ui/src/components/Card/Card.tsx
+++ b/packages/hs-react-ui/src/components/Card/Card.tsx
@@ -1,16 +1,15 @@
 import React, { ReactNode } from 'react';
 import styled, { StyledComponentBase } from 'styled-components';
-import fonts from '../../enums/fonts';
 
 import colors from '../../enums/colors';
 import timings from '../../enums/timings';
+import { Div } from '../../boilerplate';
 
-export const CardContainer = styled.div`
+export const CardContainer = styled(Div)`
   ${({ elevation = 0 }: { elevation: number }) => `
     display: inline-flex;
     flex-flow: column nowrap;
 
-    ${fonts.body}
     font-size: 1rem;
 
     border-radius: 0.25rem;
@@ -24,18 +23,18 @@ export const CardContainer = styled.div`
   `}
 `;
 
-export const Header = styled.div`
+export const Header = styled(Div)`
   padding: 1.5rem 1.5rem 0rem;
   font-weight: bold;
   color: ${colors.grayDark};
 `;
 
-export const Body = styled.div`
+export const Body = styled(Div)`
   padding: 1.5rem 1.5rem;
   color: ${colors.grayMedium};
 `;
 
-export const Footer = styled.div`
+export const Footer = styled(Div)`
   padding: 1rem 1.5rem;
   display: flex;
   flex-flow: row wrap;

--- a/packages/hs-react-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/hs-react-ui/src/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import Icon from '@mdi/react';
 import { mdiCheck, mdiCheckboxBlank, mdiClose, mdiMinus } from '@mdi/js';
 
 import colors from '../../enums/colors';
-import { Div, Input as InputElement, Label as LabelElement } from '../../boilerplate';
+import { Div, Input as InputElement, Label as LabelElement } from '../../htmlElements';
 
 export enum CheckboxTypes {
   fill = 'fill',

--- a/packages/hs-react-ui/src/components/Checkbox/Checkbox.tsx
+++ b/packages/hs-react-ui/src/components/Checkbox/Checkbox.tsx
@@ -1,9 +1,10 @@
-import React, { SyntheticEvent } from 'react';
+import React from 'react';
 import styled, { StyledComponentBase } from 'styled-components';
 import Icon from '@mdi/react';
 import { mdiCheck, mdiCheckboxBlank, mdiClose, mdiMinus } from '@mdi/js';
 
 import colors from '../../enums/colors';
+import { Div, Input as InputElement, Label as LabelElement } from '../../boilerplate';
 
 export enum CheckboxTypes {
   fill = 'fill',
@@ -15,7 +16,7 @@ export enum CheckboxTypes {
 
 // Hide checkbox visually but remain accessible to screen readers.
 // Source: https://polished.js.org/docs/#hidevisually
-export const Input = styled.input.attrs({ type: 'checkbox' })`
+export const Input = styled(InputElement).attrs({ type: 'checkbox' })`
   border: 0;
   clip: rect(0 0 0 0);
   clippath: inset(50%);
@@ -28,7 +29,7 @@ export const Input = styled.input.attrs({ type: 'checkbox' })`
   width: 1px;
 `;
 
-export const Label = styled.label`
+export const Label = styled(LabelElement)`
   display: flex;
   align-items: center;
   cursor: pointer;
@@ -38,7 +39,7 @@ export const Label = styled.label`
   }
 `;
 
-export const Box = styled.div`
+export const Box = styled(Div)`
   border: 1px solid ${colors.grayLight};
   border-radius: 2px;
   width: 0.75rem;
@@ -95,9 +96,9 @@ export interface CheckboxProps {
   StyledInput?: string & StyledComponentBase<any, {}>;
 
   checkboxType?: CheckboxTypes;
-  children?: string | Node;
+  children?: React.ReactNode;
   checked?: boolean;
-  onClick: (event: SyntheticEvent) => void;
+  onClick: (event: React.MouseEvent) => void;
 }
 
 const iconPaths = {

--- a/packages/hs-react-ui/src/components/Divider/Divider.tsx
+++ b/packages/hs-react-ui/src/components/Divider/Divider.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import styled, { StyledComponentBase } from 'styled-components';
 
 import Colors from '../../enums/colors';
+import { Div, HR } from '../../boilerplate';
 
-export const DefaultDivider = styled.hr`
+export const DefaultDivider = styled(HR)`
   ${({ width = '90%', height = '1px' }: { width: string; height: string }) => `
     border: none;
     height: ${height};
@@ -12,7 +13,7 @@ export const DefaultDivider = styled.hr`
   `}
 `;
 
-export const DefaultDividerContainer = styled.div`
+export const DefaultDividerContainer = styled(Div)`
   display: flex;
   justify-content: center;
   margin-top: 10px;

--- a/packages/hs-react-ui/src/components/Divider/Divider.tsx
+++ b/packages/hs-react-ui/src/components/Divider/Divider.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import styled, { StyledComponentBase } from 'styled-components';
 
 import Colors from '../../enums/colors';
-import { Div, HR } from '../../boilerplate';
+import { Div, HR } from '../../htmlElements';
 
 export const DefaultDivider = styled(HR)`
   ${({ width = '90%', height = '1px' }: { width: string; height: string }) => `

--- a/packages/hs-react-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/hs-react-ui/src/components/Dropdown/Dropdown.tsx
@@ -7,16 +7,15 @@ import { readableColor } from 'polished';
 import Button, { ButtonTypes } from '../Button/Button';
 import colors from '../../enums/colors';
 import timings from '../../enums/timings';
-import fonts from '../../enums/fonts';
+import { Div } from '../../boilerplate';
 
-const Container = styled.div<{ elevation: number }>`
+const Container = styled(Div)`
   ${({ elevation }) => {
     const shadowYOffset = elevation && elevation >= 1 ? (elevation - 1) * 0.5 + 0.1 : 0;
     const shadowBlur = elevation && elevation >= 1 ? (elevation - 1) * 0.5 + 0.1 : 0;
     const shadowOpacity = 0.5 - elevation * 0.075;
 
     return `
-    ${fonts.body}
     width: fit-content;
     transition: filter ${timings.slow};
     filter: drop-shadow(0rem ${shadowYOffset}rem ${shadowBlur}rem rgba(0,0,0,${shadowOpacity}));
@@ -33,7 +32,8 @@ export const ValueContainer = styled(Button.Container)`
   width: 15rem;
   padding: 0.5rem;
 `;
-const ValueIconContainer = styled.div`
+
+const ValueIconContainer = styled(Div)`
   display: flex;
   align-items: center;
   justify-content: flex-end;
@@ -42,16 +42,16 @@ const ValueIconContainer = styled.div`
 `;
 
 // TODO: Don't use explicit height here - this div is ending up larger than the icon otherwise
-const CloseIconContainer = styled.div`
+const CloseIconContainer = styled(Div)`
   height: 1.125rem;
 `;
 
-const ValueItem = styled.div`
+const ValueItem = styled(Div)`
   width: 100%;
   text-align: left;
 `;
 
-const OptionsContainer = styled.div`
+const OptionsContainer = styled(Div)`
   background: white;
   position: absolute;
   max-height: 10rem;
@@ -60,7 +60,7 @@ const OptionsContainer = styled.div`
   border: 0.5px solid ${colors.grayDark25};
 `;
 
-const OptionItem = styled.div`
+const OptionItem = styled(Div)`
   padding: 0.5rem;
   display: flex;
   align-items: center;
@@ -72,7 +72,7 @@ const OptionItem = styled.div`
     outline: none;
   }
 `;
-const CheckContainer = styled.div`
+const CheckContainer = styled(Div)`
   display: flex;
   align-items: center;
   justify-content: center;

--- a/packages/hs-react-ui/src/components/Dropdown/Dropdown.tsx
+++ b/packages/hs-react-ui/src/components/Dropdown/Dropdown.tsx
@@ -7,7 +7,7 @@ import { readableColor } from 'polished';
 import Button, { ButtonTypes } from '../Button/Button';
 import colors from '../../enums/colors';
 import timings from '../../enums/timings';
-import { Div } from '../../boilerplate';
+import { Div } from '../../htmlElements';
 
 const Container = styled(Div)`
   ${({ elevation }) => {
@@ -16,10 +16,10 @@ const Container = styled(Div)`
     const shadowOpacity = 0.5 - elevation * 0.075;
 
     return `
-    width: fit-content;
-    transition: filter ${timings.slow};
-    filter: drop-shadow(0rem ${shadowYOffset}rem ${shadowBlur}rem rgba(0,0,0,${shadowOpacity}));
-  `;
+      width: fit-content;
+      transition: filter ${timings.slow};
+      filter: drop-shadow(0rem ${shadowYOffset}rem ${shadowBlur}rem rgba(0,0,0,${shadowOpacity}));
+    `;
   }}
 `;
 // TODO - Add constants for width

--- a/packages/hs-react-ui/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/hs-react-ui/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -1,7 +1,7 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`Dropdown can focus dropdown and select option 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -13,7 +13,7 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -56,7 +56,7 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -74,7 +74,7 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
@@ -122,7 +122,7 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
 `;
 
 exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -134,7 +134,7 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -177,7 +177,7 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -195,7 +195,7 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
@@ -244,7 +244,7 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
 
 exports[`Dropdown closes options when clicking outside 1`] = `
 <DocumentFragment>
-  500;700;900&display=swap'); .c0 {
+  .c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -256,7 +256,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -299,7 +299,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -317,14 +317,14 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
-500;700;900&display=swap'); .c4 {
+.c4 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   background: white;
@@ -335,7 +335,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   border: 0.5px solid rgba(211,214,215,0.25);
 }
 
-500;700;900&display=swap'); .c5 {
+.c5 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   padding: 0.5rem;
@@ -356,7 +356,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   outline: none;
 }
 
-500;700;900&display=swap'); .c6 {
+.c6 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -454,7 +454,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
 
 exports[`Dropdown closes options when clicking outside 2`] = `
 <DocumentFragment>
-  500;700;900&display=swap'); .c0 {
+  .c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -466,7 +466,7 @@ exports[`Dropdown closes options when clicking outside 2`] = `
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -509,7 +509,7 @@ exports[`Dropdown closes options when clicking outside 2`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -527,7 +527,7 @@ exports[`Dropdown closes options when clicking outside 2`] = `
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
@@ -572,7 +572,7 @@ exports[`Dropdown closes options when clicking outside 2`] = `
 `;
 
 exports[`Dropdown deselects option when clicking on them twice when dropdown is multi 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -584,7 +584,7 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -627,7 +627,7 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -645,7 +645,7 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
@@ -691,7 +691,7 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
 `;
 
 exports[`Dropdown displays all options when focused 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -703,7 +703,7 @@ exports[`Dropdown displays all options when focused 1`] = `
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -746,7 +746,7 @@ exports[`Dropdown displays all options when focused 1`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -764,14 +764,14 @@ exports[`Dropdown displays all options when focused 1`] = `
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
-500;700;900&display=swap'); .c4 {
+.c4 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   background: white;
@@ -782,7 +782,7 @@ exports[`Dropdown displays all options when focused 1`] = `
   border: 0.5px solid rgba(211,214,215,0.25);
 }
 
-500;700;900&display=swap'); .c5 {
+.c5 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   padding: 0.5rem;
@@ -803,7 +803,7 @@ exports[`Dropdown displays all options when focused 1`] = `
   outline: none;
 }
 
-500;700;900&display=swap'); .c6 {
+.c6 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -901,7 +901,7 @@ exports[`Dropdown displays all options when focused 1`] = `
 `;
 
 exports[`Dropdown does not display options on initial render 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -913,7 +913,7 @@ exports[`Dropdown does not display options on initial render 1`] = `
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -956,7 +956,7 @@ exports[`Dropdown does not display options on initial render 1`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -974,7 +974,7 @@ exports[`Dropdown does not display options on initial render 1`] = `
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
@@ -1020,7 +1020,7 @@ exports[`Dropdown does not display options on initial render 1`] = `
 `;
 
 exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -1032,7 +1032,7 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -1075,7 +1075,7 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -1093,7 +1093,7 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
@@ -1141,7 +1141,7 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
 `;
 
 exports[`Dropdown selects options from values prop 1`] = `
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
@@ -1153,7 +1153,7 @@ exports[`Dropdown selects options from values prop 1`] = `
   filter: drop-shadow(0rem 0rem 0rem rgba(0,0,0,0.5));
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: inline-block;
@@ -1196,7 +1196,7 @@ exports[`Dropdown selects options from values prop 1`] = `
   background-color: #101317;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
@@ -1214,7 +1214,7 @@ exports[`Dropdown selects options from values prop 1`] = `
   width: 3rem;
 }
 
-500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: 100%;

--- a/packages/hs-react-ui/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
+++ b/packages/hs-react-ui/src/components/Dropdown/__tests__/__snapshots__/Dropdown.test.tsx.snap
@@ -2,6 +2,7 @@
 
 exports[`Dropdown can focus dropdown and select option 1`] = `
 500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -13,8 +14,9 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -54,7 +56,9 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -70,14 +74,16 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -85,19 +91,19 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       >
         Charmander
       </div>
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"
@@ -117,6 +123,7 @@ exports[`Dropdown can focus dropdown and select option 1`] = `
 
 exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
 500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -128,8 +135,9 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -169,7 +177,9 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -185,14 +195,16 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -200,19 +212,19 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       >
         Charmander
       </div>
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"
@@ -233,6 +245,7 @@ exports[`Dropdown can use arrow keys and enter to navigate options 1`] = `
 exports[`Dropdown closes options when clicking outside 1`] = `
 <DocumentFragment>
   500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -244,8 +257,9 @@ exports[`Dropdown closes options when clicking outside 1`] = `
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -285,7 +299,9 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -301,12 +317,16 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
-.c4 {
+500;700;900&display=swap'); .c4 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   background: white;
   position: absolute;
   max-height: 10rem;
@@ -315,7 +335,9 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   border: 0.5px solid rgba(211,214,215,0.25);
 }
 
-.c5 {
+500;700;900&display=swap'); .c5 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   padding: 0.5rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -334,7 +356,9 @@ exports[`Dropdown closes options when clicking outside 1`] = `
   outline: none;
 }
 
-.c6 {
+500;700;900&display=swap'); .c6 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -352,7 +376,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
 }
 
 <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -360,17 +384,17 @@ exports[`Dropdown closes options when clicking outside 1`] = `
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       />
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"
@@ -385,39 +409,39 @@ exports[`Dropdown closes options when clicking outside 1`] = `
       </div>
     </button>
     <div
-      class="c4"
+      class="sc-AxjAm sc-AxirZ c4"
     >
       <div
-        class="c5"
+        class="sc-AxjAm sc-AxirZ c5"
         id="choosePokemon-option-Bulbasaur"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="sc-AxjAm sc-AxirZ c6"
         />
         <span>
           Bulbasaur
         </span>
       </div>
       <div
-        class="c5"
+        class="sc-AxjAm sc-AxirZ c5"
         id="choosePokemon-option-Charmander"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="sc-AxjAm sc-AxirZ c6"
         />
         <span>
           Charmander
         </span>
       </div>
       <div
-        class="c5"
+        class="sc-AxjAm sc-AxirZ c5"
         id="choosePokemon-option-Squirtle"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="sc-AxjAm sc-AxirZ c6"
         />
         <span>
           Squirtle
@@ -431,6 +455,7 @@ exports[`Dropdown closes options when clicking outside 1`] = `
 exports[`Dropdown closes options when clicking outside 2`] = `
 <DocumentFragment>
   500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -442,8 +467,9 @@ exports[`Dropdown closes options when clicking outside 2`] = `
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -483,7 +509,9 @@ exports[`Dropdown closes options when clicking outside 2`] = `
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -499,13 +527,15 @@ exports[`Dropdown closes options when clicking outside 2`] = `
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
 <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -513,17 +543,17 @@ exports[`Dropdown closes options when clicking outside 2`] = `
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       />
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"
@@ -543,6 +573,7 @@ exports[`Dropdown closes options when clicking outside 2`] = `
 
 exports[`Dropdown deselects option when clicking on them twice when dropdown is multi 1`] = `
 500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -554,8 +585,9 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -595,7 +627,9 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -611,14 +645,16 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -626,17 +662,17 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       />
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"
@@ -656,6 +692,7 @@ exports[`Dropdown deselects option when clicking on them twice when dropdown is 
 
 exports[`Dropdown displays all options when focused 1`] = `
 500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -667,8 +704,9 @@ exports[`Dropdown displays all options when focused 1`] = `
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -708,7 +746,9 @@ exports[`Dropdown displays all options when focused 1`] = `
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -724,12 +764,16 @@ exports[`Dropdown displays all options when focused 1`] = `
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
-.c4 {
+500;700;900&display=swap'); .c4 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   background: white;
   position: absolute;
   max-height: 10rem;
@@ -738,7 +782,9 @@ exports[`Dropdown displays all options when focused 1`] = `
   border: 0.5px solid rgba(211,214,215,0.25);
 }
 
-.c5 {
+500;700;900&display=swap'); .c5 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   padding: 0.5rem;
   display: -webkit-box;
   display: -webkit-flex;
@@ -757,7 +803,9 @@ exports[`Dropdown displays all options when focused 1`] = `
   outline: none;
 }
 
-.c6 {
+500;700;900&display=swap'); .c6 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -776,7 +824,7 @@ exports[`Dropdown displays all options when focused 1`] = `
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -784,17 +832,17 @@ exports[`Dropdown displays all options when focused 1`] = `
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       />
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"
@@ -809,39 +857,39 @@ exports[`Dropdown displays all options when focused 1`] = `
       </div>
     </button>
     <div
-      class="c4"
+      class="sc-AxjAm sc-AxirZ c4"
     >
       <div
-        class="c5"
+        class="sc-AxjAm sc-AxirZ c5"
         id="choosePokemon-option-Bulbasaur"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="sc-AxjAm sc-AxirZ c6"
         />
         <span>
           Bulbasaur
         </span>
       </div>
       <div
-        class="c5"
+        class="sc-AxjAm sc-AxirZ c5"
         id="choosePokemon-option-Charmander"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="sc-AxjAm sc-AxirZ c6"
         />
         <span>
           Charmander
         </span>
       </div>
       <div
-        class="c5"
+        class="sc-AxjAm sc-AxirZ c5"
         id="choosePokemon-option-Squirtle"
         tabindex="0"
       >
         <div
-          class="c6"
+          class="sc-AxjAm sc-AxirZ c6"
         />
         <span>
           Squirtle
@@ -854,6 +902,7 @@ exports[`Dropdown displays all options when focused 1`] = `
 
 exports[`Dropdown does not display options on initial render 1`] = `
 500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -865,8 +914,9 @@ exports[`Dropdown does not display options on initial render 1`] = `
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -906,7 +956,9 @@ exports[`Dropdown does not display options on initial render 1`] = `
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -922,14 +974,16 @@ exports[`Dropdown does not display options on initial render 1`] = `
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -937,17 +991,17 @@ exports[`Dropdown does not display options on initial render 1`] = `
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       />
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"
@@ -967,6 +1021,7 @@ exports[`Dropdown does not display options on initial render 1`] = `
 
 exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
 500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -978,8 +1033,9 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -1019,7 +1075,9 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1035,14 +1093,16 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -1050,19 +1110,19 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       >
         Charmander, Squirtle
       </div>
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"
@@ -1082,6 +1142,7 @@ exports[`Dropdown selects multiple options when dropdown is multi 1`] = `
 
 exports[`Dropdown selects options from values prop 1`] = `
 500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   width: -webkit-fit-content;
   width: -moz-fit-content;
@@ -1093,8 +1154,9 @@ exports[`Dropdown selects options from values prop 1`] = `
 }
 
 500;700;900&display=swap'); .c1 {
-  display: inline-block;
+  box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
+  display: inline-block;
   font-size: 1em;
   padding: .75em 1em;
   border-radius: 0.25em;
@@ -1134,7 +1196,9 @@ exports[`Dropdown selects options from values prop 1`] = `
   background-color: #101317;
 }
 
-.c3 {
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-box;
   display: -webkit-flex;
   display: -ms-flexbox;
@@ -1150,14 +1214,16 @@ exports[`Dropdown selects options from values prop 1`] = `
   width: 3rem;
 }
 
-.c2 {
+500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   width: 100%;
   text-align: left;
 }
 
 <div>
   <div
-    class="c0"
+    class="sc-AxjAm sc-AxirZ c0"
     data-testid="choosePokemon-valueContainer"
     elevation="0"
     id="choosePokemon-valueContainer"
@@ -1165,19 +1231,19 @@ exports[`Dropdown selects options from values prop 1`] = `
     tabindex="0"
   >
     <button
-      class="sc-AxirZ c1"
+      class="sc-AxhUy sc-AxgMl sc-fzoXzr c1"
       color="#252c35"
       data-test-id="hsui-button"
       elevation="0"
       type="fill"
     >
       <div
-        class="c2"
+        class="sc-AxjAm sc-AxirZ c2"
       >
         Bulbasaur, Charmander
       </div>
       <div
-        class="c3"
+        class="sc-AxjAm sc-AxirZ c3"
       >
         <svg
           role="presentation"

--- a/packages/hs-react-ui/src/components/Label/Label.stories.tsx
+++ b/packages/hs-react-ui/src/components/Label/Label.stories.tsx
@@ -17,8 +17,8 @@ storiesOf('Label', module).add(
     <Label
       labelText={text('labelText', 'This is the label text')}
       color={select('Color', colors, colors.grayDark)}
-      colorValid={select('ColorValid', colors, colors.success)}
-      colorInvalid={select('ColorInvalid', colors, colors.destructive)}
+      colorValid={select('colorValid', colors, colors.success)}
+      colorInvalid={select('colorInvalid', colors, colors.destructive)}
       isRequired={boolean('isRequired', false)}
       // eslint-disable-next-line @typescript-eslint/ban-ts-comment
       // @ts-ignore

--- a/packages/hs-react-ui/src/components/Label/Label.tsx
+++ b/packages/hs-react-ui/src/components/Label/Label.tsx
@@ -4,8 +4,9 @@ import Icon from '@mdi/react';
 import { mdiCheckBold, mdiAsterisk } from '@mdi/js';
 import fonts from '../../enums/fonts';
 import colors from '../../enums/colors';
+import { Div, Label as LabelElement, Span } from '../../boilerplate';
 
-export const DefaultStyledLabel = styled.label`
+export const DefaultStyledLabel = styled(LabelElement)`
   ${({ color = colors.grayLight }: { color: colors | string }) => `
     display: inline-flex;
     color: ${color};
@@ -15,11 +16,11 @@ export const DefaultStyledLabel = styled.label`
   `}
 `;
 
-export const DefaultStyledTextContainer = styled.div``;
+export const DefaultStyledTextContainer = styled(Div)``;
 
-export const DefaultStyledLabelContainer = styled.div``;
+export const DefaultStyledLabelContainer = styled(Div)``;
 
-const DefaultStyledIconContainer = styled.span`
+const DefaultStyledIconContainer = styled(Span)`
   display: inline-flex;
   margin-left: 0.25rem;
 `;
@@ -32,7 +33,7 @@ export interface LabelProps {
   colorInvalid?: colors | string;
   htmlFor?: string;
   isRequired?: boolean;
-  children?: any;
+  children?: React.ReactNode;
   StyledLabelContainer?: string & StyledComponentBase<any, {}>;
   StyledTextContainer?: string & StyledComponentBase<any, {}>;
   StyledLabel?: string & StyledComponentBase<any, {}>;

--- a/packages/hs-react-ui/src/components/Label/Label.tsx
+++ b/packages/hs-react-ui/src/components/Label/Label.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import styled, { StyledComponentBase } from 'styled-components';
 import Icon from '@mdi/react';
 import { mdiCheckBold, mdiAsterisk } from '@mdi/js';
-import fonts from '../../enums/fonts';
 import colors from '../../enums/colors';
 import { Div, Label as LabelElement, Span } from '../../htmlElements';
 
@@ -10,7 +9,6 @@ export const DefaultStyledLabel = styled(LabelElement)`
   ${({ color = colors.grayLight }: { color: colors | string }) => `
     display: inline-flex;
     color: ${color};
-    ${fonts.body}
     margin-bottom: .25em;
     font-size: .75em;
   `}

--- a/packages/hs-react-ui/src/components/Label/Label.tsx
+++ b/packages/hs-react-ui/src/components/Label/Label.tsx
@@ -4,7 +4,7 @@ import Icon from '@mdi/react';
 import { mdiCheckBold, mdiAsterisk } from '@mdi/js';
 import fonts from '../../enums/fonts';
 import colors from '../../enums/colors';
-import { Div, Label as LabelElement, Span } from '../../boilerplate';
+import { Div, Label as LabelElement, Span } from '../../htmlElements';
 
 export const DefaultStyledLabel = styled(LabelElement)`
   ${({ color = colors.grayLight }: { color: colors | string }) => `

--- a/packages/hs-react-ui/src/components/Label/__tests__/Label.test.tsx
+++ b/packages/hs-react-ui/src/components/Label/__tests__/Label.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { render, fireEvent, waitFor } from '@testing-library/react';
+import { render } from '@testing-library/react';
 
 import Label from '../Label';
 

--- a/packages/hs-react-ui/src/components/Label/__tests__/Label.test.tsx
+++ b/packages/hs-react-ui/src/components/Label/__tests__/Label.test.tsx
@@ -5,30 +5,30 @@ import Label from '../Label';
 
 describe('Label', () => {
   it('should have text be colorInvalid if given a isValid prop of false', () => {
-    const labelToTest = render(
+    const { container } = render(
       <Label labelText="Test text" colorInvalid={'#9400D3'} isRequired={true} isValid={false} />,
     );
 
-    expect(labelToTest).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('should have text be colorValid and a check icon if given a isValid prop of true', () => {
-    const labelToTest = render(
+    const { container } = render(
       <Label labelText="Test text" colorValid={'#0000FF'} isRequired={true} isValid={true} />,
     );
 
-    expect(labelToTest).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('should have default color text if not given a isValid', () => {
-    const labelToTest = render(<Label color={'#FF4500'} labelText="Test text" />);
+    const container = render(<Label color={'#FF4500'} labelText="Test text" />);
 
-    expect(labelToTest).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 
   it('should have asterisk icon if isRequired is true', () => {
-    const labelToTest = render(<Label labelText="Test text" isRequired={true} />);
+    const container = render(<Label labelText="Test text" isRequired={true} />);
 
-    expect(labelToTest).toMatchSnapshot();
+    expect(container).toMatchSnapshot();
   });
 });

--- a/packages/hs-react-ui/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/packages/hs-react-ui/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -4,7 +4,7 @@ exports[`Label should have asterisk icon if isRequired is true 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    500;700;900&display=swap'); @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); .c2 {
+    .c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
@@ -12,22 +12,21 @@ Object {
   display: -ms-inline-flexbox;
   display: inline-flex;
   color: #7c8186;
-  font-family: Montserrat,Roboto,sans-serif;
   margin-bottom: .25em;
   font-size: .75em;
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
 }
 
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
@@ -71,20 +70,20 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="sc-AxjAm sc-AxirZ sc-fzpjYC fEsBZT"
+      class="sc-AxjAm sc-AxirZ sc-fzpjYC fZIUoG"
     >
       <div
-        class="sc-AxjAm sc-AxirZ sc-fzoXzr kaRujs"
+        class="sc-AxjAm sc-AxirZ sc-fzoXzr lojETd"
       >
         <label
-          class="sc-AxmLO sc-fzozJi sc-fzoLag kAlzJl"
+          class="sc-AxmLO sc-fzozJi sc-fzoLag gnhNZK"
           color="#7c8186"
           for="default"
         >
           Test text
         </label>
         <span
-          class="sc-AxiKw sc-AxhCb sc-fznxsB ENtBQ"
+          class="sc-AxiKw sc-AxhCb sc-fznxsB jDTVXZ"
         >
           <svg
             role="presentation"
@@ -157,8 +156,7 @@ Object {
 exports[`Label should have default color text if not given a isValid 1`] = `
 Object {
   "asFragment": [Function],
-  "baseElement": <body>
-    500;700;900&display=swap'); @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); .c2 {
+  "baseElement": .c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
@@ -166,22 +164,21 @@ Object {
   display: -ms-inline-flexbox;
   display: inline-flex;
   color: #FF4500;
-  font-family: Montserrat,Roboto,sans-serif;
   margin-bottom: .25em;
   font-size: .75em;
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
 }
 
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
 }
 
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
@@ -191,7 +188,8 @@ Object {
   margin-left: 0.25rem;
 }
 
-<div>
+<body>
+    <div>
       <div
         class="sc-AxjAm sc-AxirZ c0"
       >
@@ -225,20 +223,20 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="sc-AxjAm sc-AxirZ sc-fzpjYC fEsBZT"
+      class="sc-AxjAm sc-AxirZ sc-fzpjYC fZIUoG"
     >
       <div
-        class="sc-AxjAm sc-AxirZ sc-fzoXzr kaRujs"
+        class="sc-AxjAm sc-AxirZ sc-fzoXzr lojETd"
       >
         <label
-          class="sc-AxmLO sc-fzozJi sc-fzoLag bWeSID"
+          class="sc-AxmLO sc-fzozJi sc-fzoLag iekDaY"
           color="#FF4500"
           for="default"
         >
           Test text
         </label>
         <span
-          class="sc-AxiKw sc-AxhCb sc-fznxsB ENtBQ"
+          class="sc-AxiKw sc-AxhCb sc-fznxsB jDTVXZ"
         >
           <svg
             role="presentation"
@@ -309,9 +307,7 @@ Object {
 `;
 
 exports[`Label should have text be colorInvalid if given a isValid prop of false 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": 500;700;900&display=swap'); @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); .c2 {
+.c2 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
@@ -319,177 +315,21 @@ Object {
   display: -ms-inline-flexbox;
   display: inline-flex;
   color: #9400D3;
-  font-family: Montserrat,Roboto,sans-serif;
   margin-bottom: .25em;
   font-size: .75em;
 }
 
-500;700;900&display=swap'); .c1 {
+.c1 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
 }
 
-500;700;900&display=swap'); .c0 {
+.c0 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
 }
 
-500;700;900&display=swap'); .c3 {
-  box-sizing: border-box;
-  font-family: Montserrat,Roboto,sans-serif;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  margin-left: 0.25rem;
-}
-
-<body>
-    <div>
-      <div
-        class="sc-AxjAm sc-AxirZ c0"
-      >
-        <div
-          class="sc-AxjAm sc-AxirZ c1"
-        >
-          <label
-            class="sc-AxmLO sc-fzozJi c2"
-            color="#9400D3"
-            for="default"
-          >
-            Test text
-          </label>
-          <span
-            class="sc-AxiKw sc-AxhCb c3"
-          >
-            <svg
-              role="presentation"
-              style="width: .75rem; height: .75rem;"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M10,2H14L13.21,9.91L19.66,5.27L21.66,8.73L14.42,12L21.66,15.27L19.66,18.73L13.21,14.09L14,22H10L10.79,14.09L4.34,18.73L2.34,15.27L9.58,12L2.34,8.73L4.34,5.27L10.79,9.91L10,2Z"
-                style="fill: #9400D3;"
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
-    <div
-      class="sc-AxjAm sc-AxirZ sc-fzpjYC fEsBZT"
-    >
-      <div
-        class="sc-AxjAm sc-AxirZ sc-fzoXzr kaRujs"
-      >
-        <label
-          class="sc-AxmLO sc-fzozJi sc-fzoLag cXViwM"
-          color="#9400D3"
-          for="default"
-        >
-          Test text
-        </label>
-        <span
-          class="sc-AxiKw sc-AxhCb sc-fznxsB ENtBQ"
-        >
-          <svg
-            role="presentation"
-            style="width: .75rem; height: .75rem;"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M10,2H14L13.21,9.91L19.66,5.27L21.66,8.73L14.42,12L21.66,15.27L19.66,18.73L13.21,14.09L14,22H10L10.79,14.09L4.34,18.73L2.34,15.27L9.58,12L2.34,8.73L4.34,5.27L10.79,9.91L10,2Z"
-              style="fill: #9400D3;"
-            />
-          </svg>
-        </span>
-      </div>
-    </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
-}
-`;
-
-exports[`Label should have text be colorValid and a check icon if given a isValid prop of true 1`] = `
-Object {
-  "asFragment": [Function],
-  "baseElement": <body>
-    500;700;900&display=swap'); @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); .c2 {
-  box-sizing: border-box;
-  font-family: Montserrat,Roboto,sans-serif;
-  display: -webkit-inline-box;
-  display: -webkit-inline-flex;
-  display: -ms-inline-flexbox;
-  display: inline-flex;
-  color: #0000FF;
-  font-family: Montserrat,Roboto,sans-serif;
-  margin-bottom: .25em;
-  font-size: .75em;
-}
-
-500;700;900&display=swap'); .c1 {
-  box-sizing: border-box;
-  font-family: Montserrat,Roboto,sans-serif;
-}
-
-500;700;900&display=swap'); .c0 {
-  box-sizing: border-box;
-  font-family: Montserrat,Roboto,sans-serif;
-}
-
-500;700;900&display=swap'); .c3 {
+.c3 {
   box-sizing: border-box;
   font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
@@ -500,118 +340,100 @@ Object {
 }
 
 <div>
-      <div
-        class="sc-AxjAm sc-AxirZ c0"
-      >
-        <div
-          class="sc-AxjAm sc-AxirZ c1"
-        >
-          <label
-            class="sc-AxmLO sc-fzozJi c2"
-            color="#0000FF"
-            for="default"
-          >
-            Test text
-          </label>
-          <span
-            class="sc-AxiKw sc-AxhCb c3"
-          >
-            <svg
-              role="presentation"
-              style="width: .75rem; height: .75rem;"
-              viewBox="0 0 24 24"
-            >
-              <path
-                d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"
-                style="fill: #0000FF;"
-              />
-            </svg>
-          </span>
-        </div>
-      </div>
-    </div>
-  </body>,
-  "container": <div>
+  <div
+    class="sc-AxjAm sc-AxirZ c0"
+  >
     <div
-      class="sc-AxjAm sc-AxirZ sc-fzpjYC fEsBZT"
+      class="sc-AxjAm sc-AxirZ c1"
     >
-      <div
-        class="sc-AxjAm sc-AxirZ sc-fzoXzr kaRujs"
+      <label
+        class="sc-AxmLO sc-fzozJi c2"
+        color="#9400D3"
+        for="default"
       >
-        <label
-          class="sc-AxmLO sc-fzozJi sc-fzoLag fhQidO"
-          color="#0000FF"
-          for="default"
+        Test text
+      </label>
+      <span
+        class="sc-AxiKw sc-AxhCb c3"
+      >
+        <svg
+          role="presentation"
+          style="width: .75rem; height: .75rem;"
+          viewBox="0 0 24 24"
         >
-          Test text
-        </label>
-        <span
-          class="sc-AxiKw sc-AxhCb sc-fznxsB ENtBQ"
-        >
-          <svg
-            role="presentation"
-            style="width: .75rem; height: .75rem;"
-            viewBox="0 0 24 24"
-          >
-            <path
-              d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"
-              style="fill: #0000FF;"
-            />
-          </svg>
-        </span>
-      </div>
+          <path
+            d="M10,2H14L13.21,9.91L19.66,5.27L21.66,8.73L14.42,12L21.66,15.27L19.66,18.73L13.21,14.09L14,22H10L10.79,14.09L4.34,18.73L2.34,15.27L9.58,12L2.34,8.73L4.34,5.27L10.79,9.91L10,2Z"
+            style="fill: #9400D3;"
+          />
+        </svg>
+      </span>
     </div>
-  </div>,
-  "debug": [Function],
-  "findAllByAltText": [Function],
-  "findAllByDisplayValue": [Function],
-  "findAllByLabelText": [Function],
-  "findAllByPlaceholderText": [Function],
-  "findAllByRole": [Function],
-  "findAllByTestId": [Function],
-  "findAllByText": [Function],
-  "findAllByTitle": [Function],
-  "findByAltText": [Function],
-  "findByDisplayValue": [Function],
-  "findByLabelText": [Function],
-  "findByPlaceholderText": [Function],
-  "findByRole": [Function],
-  "findByTestId": [Function],
-  "findByText": [Function],
-  "findByTitle": [Function],
-  "getAllByAltText": [Function],
-  "getAllByDisplayValue": [Function],
-  "getAllByLabelText": [Function],
-  "getAllByPlaceholderText": [Function],
-  "getAllByRole": [Function],
-  "getAllByTestId": [Function],
-  "getAllByText": [Function],
-  "getAllByTitle": [Function],
-  "getByAltText": [Function],
-  "getByDisplayValue": [Function],
-  "getByLabelText": [Function],
-  "getByPlaceholderText": [Function],
-  "getByRole": [Function],
-  "getByTestId": [Function],
-  "getByText": [Function],
-  "getByTitle": [Function],
-  "queryAllByAltText": [Function],
-  "queryAllByDisplayValue": [Function],
-  "queryAllByLabelText": [Function],
-  "queryAllByPlaceholderText": [Function],
-  "queryAllByRole": [Function],
-  "queryAllByTestId": [Function],
-  "queryAllByText": [Function],
-  "queryAllByTitle": [Function],
-  "queryByAltText": [Function],
-  "queryByDisplayValue": [Function],
-  "queryByLabelText": [Function],
-  "queryByPlaceholderText": [Function],
-  "queryByRole": [Function],
-  "queryByTestId": [Function],
-  "queryByText": [Function],
-  "queryByTitle": [Function],
-  "rerender": [Function],
-  "unmount": [Function],
+  </div>
+</div>
+`;
+
+exports[`Label should have text be colorValid and a check icon if given a isValid prop of true 1`] = `
+.c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  color: #0000FF;
+  margin-bottom: .25em;
+  font-size: .75em;
 }
+
+.c1 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+.c0 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+.c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+  display: -webkit-inline-box;
+  display: -webkit-inline-flex;
+  display: -ms-inline-flexbox;
+  display: inline-flex;
+  margin-left: 0.25rem;
+}
+
+<div>
+  <div
+    class="sc-AxjAm sc-AxirZ c0"
+  >
+    <div
+      class="sc-AxjAm sc-AxirZ c1"
+    >
+      <label
+        class="sc-AxmLO sc-fzozJi c2"
+        color="#0000FF"
+        for="default"
+      >
+        Test text
+      </label>
+      <span
+        class="sc-AxiKw sc-AxhCb c3"
+      >
+        <svg
+          role="presentation"
+          style="width: .75rem; height: .75rem;"
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M9,20.42L2.79,14.21L5.62,11.38L9,14.77L18.88,4.88L21.71,7.71L9,20.42Z"
+            style="fill: #0000FF;"
+          />
+        </svg>
+      </span>
+    </div>
+  </div>
+</div>
 `;

--- a/packages/hs-react-ui/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
+++ b/packages/hs-react-ui/src/components/Label/__tests__/__snapshots__/Label.test.tsx.snap
@@ -4,7 +4,9 @@ exports[`Label should have asterisk icon if isRequired is true 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    500;700;900&display=swap'); .c0 {
+    500;700;900&display=swap'); @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -15,7 +17,19 @@ Object {
   font-size: .75em;
 }
 
-.c1 {
+500;700;900&display=swap'); .c1 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -25,20 +39,20 @@ Object {
 
 <div>
       <div
-        class=""
+        class="sc-AxjAm sc-AxirZ c0"
       >
         <div
-          class=""
+          class="sc-AxjAm sc-AxirZ c1"
         >
           <label
-            class="c0"
+            class="sc-AxmLO sc-fzozJi c2"
             color="#7c8186"
             for="default"
           >
             Test text
           </label>
           <span
-            class="c1"
+            class="sc-AxiKw sc-AxhCb c3"
           >
             <svg
               role="presentation"
@@ -57,20 +71,20 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="sc-AxiKw bOTXee"
+      class="sc-AxjAm sc-AxirZ sc-fzpjYC fEsBZT"
     >
       <div
-        class="sc-AxirZ ktnnZK"
+        class="sc-AxjAm sc-AxirZ sc-fzoXzr kaRujs"
       >
         <label
-          class="sc-AxjAm drAbMu"
+          class="sc-AxmLO sc-fzozJi sc-fzoLag kAlzJl"
           color="#7c8186"
           for="default"
         >
           Test text
         </label>
         <span
-          class="sc-AxhCb caZSwy"
+          class="sc-AxiKw sc-AxhCb sc-fznxsB ENtBQ"
         >
           <svg
             role="presentation"
@@ -144,7 +158,9 @@ exports[`Label should have default color text if not given a isValid 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    500;700;900&display=swap'); .c0 {
+    500;700;900&display=swap'); @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -155,7 +171,19 @@ Object {
   font-size: .75em;
 }
 
-.c1 {
+500;700;900&display=swap'); .c1 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -165,20 +193,20 @@ Object {
 
 <div>
       <div
-        class=""
+        class="sc-AxjAm sc-AxirZ c0"
       >
         <div
-          class=""
+          class="sc-AxjAm sc-AxirZ c1"
         >
           <label
-            class="c0"
+            class="sc-AxmLO sc-fzozJi c2"
             color="#FF4500"
             for="default"
           >
             Test text
           </label>
           <span
-            class="c1"
+            class="sc-AxiKw sc-AxhCb c3"
           >
             <svg
               role="presentation"
@@ -197,20 +225,20 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="sc-AxiKw bOTXee"
+      class="sc-AxjAm sc-AxirZ sc-fzpjYC fEsBZT"
     >
       <div
-        class="sc-AxirZ ktnnZK"
+        class="sc-AxjAm sc-AxirZ sc-fzoXzr kaRujs"
       >
         <label
-          class="sc-AxjAm bIrdOE"
+          class="sc-AxmLO sc-fzozJi sc-fzoLag bWeSID"
           color="#FF4500"
           for="default"
         >
           Test text
         </label>
         <span
-          class="sc-AxhCb caZSwy"
+          class="sc-AxiKw sc-AxhCb sc-fznxsB ENtBQ"
         >
           <svg
             role="presentation"
@@ -283,7 +311,9 @@ Object {
 exports[`Label should have text be colorInvalid if given a isValid prop of false 1`] = `
 Object {
   "asFragment": [Function],
-  "baseElement": 500;700;900&display=swap'); .c0 {
+  "baseElement": 500;700;900&display=swap'); @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -294,7 +324,19 @@ Object {
   font-size: .75em;
 }
 
-.c1 {
+500;700;900&display=swap'); .c1 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -305,20 +347,20 @@ Object {
 <body>
     <div>
       <div
-        class=""
+        class="sc-AxjAm sc-AxirZ c0"
       >
         <div
-          class=""
+          class="sc-AxjAm sc-AxirZ c1"
         >
           <label
-            class="c0"
+            class="sc-AxmLO sc-fzozJi c2"
             color="#9400D3"
             for="default"
           >
             Test text
           </label>
           <span
-            class="c1"
+            class="sc-AxiKw sc-AxhCb c3"
           >
             <svg
               role="presentation"
@@ -337,20 +379,20 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="sc-AxiKw bOTXee"
+      class="sc-AxjAm sc-AxirZ sc-fzpjYC fEsBZT"
     >
       <div
-        class="sc-AxirZ ktnnZK"
+        class="sc-AxjAm sc-AxirZ sc-fzoXzr kaRujs"
       >
         <label
-          class="sc-AxjAm dRrrWL"
+          class="sc-AxmLO sc-fzozJi sc-fzoLag cXViwM"
           color="#9400D3"
           for="default"
         >
           Test text
         </label>
         <span
-          class="sc-AxhCb caZSwy"
+          class="sc-AxiKw sc-AxhCb sc-fznxsB ENtBQ"
         >
           <svg
             role="presentation"
@@ -424,7 +466,9 @@ exports[`Label should have text be colorValid and a check icon if given a isVali
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    500;700;900&display=swap'); .c0 {
+    500;700;900&display=swap'); @import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); .c2 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -435,7 +479,19 @@ Object {
   font-size: .75em;
 }
 
-.c1 {
+500;700;900&display=swap'); .c1 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+500;700;900&display=swap'); .c0 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
+}
+
+500;700;900&display=swap'); .c3 {
+  box-sizing: border-box;
+  font-family: Montserrat,Roboto,sans-serif;
   display: -webkit-inline-box;
   display: -webkit-inline-flex;
   display: -ms-inline-flexbox;
@@ -445,20 +501,20 @@ Object {
 
 <div>
       <div
-        class=""
+        class="sc-AxjAm sc-AxirZ c0"
       >
         <div
-          class=""
+          class="sc-AxjAm sc-AxirZ c1"
         >
           <label
-            class="c0"
+            class="sc-AxmLO sc-fzozJi c2"
             color="#0000FF"
             for="default"
           >
             Test text
           </label>
           <span
-            class="c1"
+            class="sc-AxiKw sc-AxhCb c3"
           >
             <svg
               role="presentation"
@@ -477,20 +533,20 @@ Object {
   </body>,
   "container": <div>
     <div
-      class="sc-AxiKw bOTXee"
+      class="sc-AxjAm sc-AxirZ sc-fzpjYC fEsBZT"
     >
       <div
-        class="sc-AxirZ ktnnZK"
+        class="sc-AxjAm sc-AxirZ sc-fzoXzr kaRujs"
       >
         <label
-          class="sc-AxjAm errOZt"
+          class="sc-AxmLO sc-fzozJi sc-fzoLag fhQidO"
           color="#0000FF"
           for="default"
         >
           Test text
         </label>
         <span
-          class="sc-AxhCb caZSwy"
+          class="sc-AxiKw sc-AxhCb sc-fznxsB ENtBQ"
         >
           <svg
             role="presentation"

--- a/packages/hs-react-ui/src/components/Modal/Modal.tsx
+++ b/packages/hs-react-ui/src/components/Modal/Modal.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import styled, { StyledComponentBase } from 'styled-components';
 import Card from '../Card';
 import { Footer, Header } from '../Card/Card';
-import { Div, Span } from '../../boilerplate';
+import { Div, Span } from '../../htmlElements';
 
 export interface ModalProps {
   // TODO: Make string & StyledComponentBase<> its own type, also see about not using `any`

--- a/packages/hs-react-ui/src/components/Modal/Modal.tsx
+++ b/packages/hs-react-ui/src/components/Modal/Modal.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import styled, { StyledComponentBase } from 'styled-components';
 import Card from '../Card';
 import { Footer, Header } from '../Card/Card';
+import { Div, Span } from '../../boilerplate';
 
 export interface ModalProps {
   // TODO: Make string & StyledComponentBase<> its own type, also see about not using `any`
@@ -22,7 +23,7 @@ export interface ModalProps {
   backgroundDarkness?: number;
 }
 
-const ModalUnderlay = styled.div<{ backgroundBlur: string; backgroundDarkness: number }>`
+const ModalUnderlay = styled(Div)<{ backgroundBlur: string; backgroundDarkness: number }>`
   ${({ backgroundBlur = '0', backgroundDarkness = 0 }) => `
     height: 100%;
     width: 100%;
@@ -37,7 +38,7 @@ const ModalUnderlay = styled.div<{ backgroundBlur: string; backgroundDarkness: n
   `}
 `;
 
-const ModalContainer = styled.div`
+const ModalContainer = styled(Div)`
   position: fixed;
   top: 50%;
   left: 50%;
@@ -55,7 +56,7 @@ const ModalFooter = styled(Footer)`
   justify-content: flex-end;
 `;
 
-const ModalCloseButton = styled.span`
+const ModalCloseButton = styled(Span)`
   position: absolute;
   top: 1rem;
   right: 1rem;

--- a/packages/hs-react-ui/src/components/Progress/Progress.tsx
+++ b/packages/hs-react-ui/src/components/Progress/Progress.tsx
@@ -1,5 +1,5 @@
 import styled, { keyframes, css } from 'styled-components';
-import { Div } from '../../boilerplate';
+import { Div } from '../../htmlElements';
 
 /* Keyframes for the loading bar gradient */
 export const movingGradient = keyframes`

--- a/packages/hs-react-ui/src/components/Progress/Progress.tsx
+++ b/packages/hs-react-ui/src/components/Progress/Progress.tsx
@@ -1,4 +1,5 @@
 import styled, { keyframes, css } from 'styled-components';
+import { Div } from '../../boilerplate';
 
 /* Keyframes for the loading bar gradient */
 export const movingGradient = keyframes`
@@ -13,7 +14,7 @@ export const animation = css`
 
 /* Styled div that represents the scroll bar
    Note: The border-radius 9999px is used to create a pill shape */
-const Progress = styled.div`
+const Progress = styled(Div)`
   ${() => css`
     background: linear-gradient(
         45deg,

--- a/packages/hs-react-ui/src/components/Table/Table.stories.tsx
+++ b/packages/hs-react-ui/src/components/Table/Table.stories.tsx
@@ -353,7 +353,7 @@ storiesOf('Table', module)
           data={rows}
           sortGroups={boolean('sortGroups', false)}
           groupHeaderPosition={position}
-          areGroupsCollapsable={boolean('areGroupsCollapsable', false)}
+          areGroupsCollapsible={boolean('areGroupsCollapsible', false)}
           expansionIconComponent={useCustomLabel ? expansionIconOverride : undefined}
         />
       );

--- a/packages/hs-react-ui/src/components/Table/Table.tsx
+++ b/packages/hs-react-ui/src/components/Table/Table.tsx
@@ -4,11 +4,9 @@ import useResizeObserver from 'use-resize-observer/polyfilled';
 import { mdiArrowDown, mdiChevronRight, mdiChevronDown, mdiChevronUp } from '@mdi/js';
 import Icon from '@mdi/react';
 import colors from '../../enums/colors';
-import fonts from '../../enums/fonts';
 import { Span, Table as TableElement, TD, TH, TR } from '../../htmlElements';
 
 /* Types and Interfaces */
-
 export type CellOptions = {
   RenderedCell: any;
   headerColumnKey: string;

--- a/packages/hs-react-ui/src/components/Table/Table.tsx
+++ b/packages/hs-react-ui/src/components/Table/Table.tsx
@@ -85,7 +85,6 @@ const StyledExpansionIconSpan = styled(Span)`
 export const TableContainer = styled(TableElement)`
   ${({ reachedMinWidth }: { reachedMinWidth?: boolean }) => `
     width: ${reachedMinWidth ? '100%' : 'auto'};
-    ${fonts.body}
     background-color: ${colors.background};
     border-collapse: collapse;
 

--- a/packages/hs-react-ui/src/components/Table/Table.tsx
+++ b/packages/hs-react-ui/src/components/Table/Table.tsx
@@ -5,6 +5,7 @@ import { mdiArrowDown, mdiChevronRight, mdiChevronDown, mdiChevronUp } from '@md
 import Icon from '@mdi/react';
 import colors from '../../enums/colors';
 import fonts from '../../enums/fonts';
+import { Span, Table as TableElement, TD, TH, TR } from '../../boilerplate';
 
 /* Types and Interfaces */
 
@@ -48,7 +49,7 @@ export interface columnTypes {
 }
 
 export type TableProps = {
-  areGroupsCollapsable?: boolean;
+  areGroupsCollapsible?: boolean;
   columnGap?: string;
   columns: columnTypes;
   data?: columnTypes[] | Array<Array<columnTypes>>;
@@ -77,11 +78,11 @@ type collapsedState = { [key: string]: string };
 
 /** Start of styled components */
 
-const StyledExpansionIconSpan = styled.span`
+const StyledExpansionIconSpan = styled(Span)`
   cursor: pointer;
 `;
 
-export const TableContainer = styled.table`
+export const TableContainer = styled(TableElement)`
   ${({ reachedMinWidth }: { reachedMinWidth?: boolean }) => `
     width: ${reachedMinWidth ? '100%' : 'auto'};
     ${fonts.body}
@@ -93,7 +94,7 @@ export const TableContainer = styled.table`
   `}
 `;
 
-export const Header = styled.tr`
+export const Header = styled(TR)`
   ${({ columnGap, columnWidths }: RowProps) => `
     display: grid;
     grid-template-columns: ${columnWidths};
@@ -106,7 +107,7 @@ export const Header = styled.tr`
   `}
 `;
 
-export const HeaderCell = styled.th`
+export const HeaderCell = styled(TH)`
   ${({ sortable }: { sortable: boolean }) => `
     display: flex;
     flex-flow: row;
@@ -124,7 +125,7 @@ export const HeaderCell = styled.th`
   `}
 `;
 
-export const ResponsiveTitle = styled.span`
+export const ResponsiveTitle = styled(Span)`
   ${({ sortable }: { sortable: boolean }) => `
     color: ${colors.primary};
     padding: 0.5rem;
@@ -137,7 +138,7 @@ export const ResponsiveTitle = styled.span`
   `}
 `;
 
-export const Row = styled.tr`
+export const Row = styled(TR)`
   ${({ columnGap, columnWidths, reachedMinWidth, isCollapsed = false }: RowProps) => `
     display: grid;
     grid-template-columns: ${reachedMinWidth ? '100%' : columnWidths};
@@ -175,7 +176,7 @@ export const GroupRow = styled(Row)`
   background-color: ${colors.grayXlight};
 `;
 
-export const Cell = styled.td`
+export const Cell = styled(TD)`
   display: block;
   padding: 1rem 0rem;
   word-break: break-word;
@@ -232,12 +233,12 @@ export const ExpansionIconColumnName = '__EXPANSION_COLUMN__';
 
 // TODO: Add the table width observer to a container which fills the area, so the table can grow
 // once there is enough room for it to do so (if the table itself isn't full width)
-// TODO: Add window width media query to compliment the table width media query API
+// TODO: Add window width media query to complement the table width media query API
 
 const Table = ({
   columnGap = '1rem',
   columns,
-  areGroupsCollapsable = false,
+  areGroupsCollapsible = false,
   data = [],
   defaultSort = ['', false], // key, direction
   groupHeaderPosition = 'above',
@@ -258,7 +259,7 @@ const Table = ({
 
   const usingGroups: boolean = data && data.length > 0 && Array.isArray(data[0]);
   const copiedColumns = { ...columns }; // Shallow copy so not to manipulate props
-  if (areGroupsCollapsable && !copiedColumns[ExpansionIconColumnName]) {
+  if (areGroupsCollapsible && !copiedColumns[ExpansionIconColumnName]) {
     copiedColumns[ExpansionIconColumnName] = collapsedExpandedIconColumn;
   }
 
@@ -367,7 +368,7 @@ const Table = ({
    * @param {columnTypes} options.row - the data for the row, each cell should be able to the row's data
    * @param {number} options.index - The index of the cell in the row
    * @param {number} options.indexModifier - Used only when creating cells in a group. Used to account for group labels
-   * @param {any} options.CollapseExpandedIcon - Component to be used for the collapse icon. Only used for collapsable group label cells
+   * @param {any} options.CollapseExpandedIcon - Component to be used for the collapse icon. Only used for collapsible group label cells
    * @param {number} options.groupIndex - The index of the group. Used only when creating cells as part of a group
    * @param {boolean} options.isCollapsed - Used when creating cells with a CollapseExpandedIcon
    * @param {string} options.groupLabelDataString - The stringified version of the group label row
@@ -412,7 +413,7 @@ const Table = ({
           {row && row[headerColumnKey]}
           {CollapseExpandedIcon &&
           usingGroups &&
-          areGroupsCollapsable &&
+          areGroupsCollapsible &&
           headerColumnKey === ExpansionIconColumnName ? (
             <CollapseExpandedIcon
               isCollapsed={isCollapsed}
@@ -466,7 +467,7 @@ const Table = ({
               rowNum={index + indexModifier}
               key={`row${JSON.stringify(row) + index}`}
               reachedMinWidth={width < minWidthBreakpoint}
-              isCollapsed={areGroupsCollapsable && isCollapsed}
+              isCollapsed={areGroupsCollapsible && isCollapsed}
             >
               {Object.keys(copiedColumns).map(headerColumnKey => {
                 const RenderedCell = copiedColumns[headerColumnKey].cellComponent || StyledCell;

--- a/packages/hs-react-ui/src/components/Table/Table.tsx
+++ b/packages/hs-react-ui/src/components/Table/Table.tsx
@@ -5,7 +5,7 @@ import { mdiArrowDown, mdiChevronRight, mdiChevronDown, mdiChevronUp } from '@md
 import Icon from '@mdi/react';
 import colors from '../../enums/colors';
 import fonts from '../../enums/fonts';
-import { Span, Table as TableElement, TD, TH, TR } from '../../boilerplate';
+import { Span, Table as TableElement, TD, TH, TR } from '../../htmlElements';
 
 /* Types and Interfaces */
 

--- a/packages/hs-react-ui/src/components/Text/Text.tsx
+++ b/packages/hs-react-ui/src/components/Text/Text.tsx
@@ -5,9 +5,10 @@ import Icon from '@mdi/react';
 import { mdiLoading } from '@mdi/js';
 import fonts from '../../enums/fonts';
 import Progress from '../Progress/Progress';
+import { Span } from '../../boilerplate';
 
 /* Default Styled Text Container */
-export const TextContainer = styled.span`
+export const TextContainer = styled(Span)`
   ${({ size, color }: { size: string; color: string }) => `
     ${fonts.body}
     font-size: ${size};
@@ -35,7 +36,7 @@ const StyledProgress = styled(Progress)`
   `}
 `;
 
-const IconContainer = styled.span`
+const IconContainer = styled(Span)`
   ${({ side }: { side: 'left' | 'right' }) => `
     margin-${side === 'left' ? 'right' : 'left'}: .5em;
     display: inline-flex;

--- a/packages/hs-react-ui/src/components/Text/Text.tsx
+++ b/packages/hs-react-ui/src/components/Text/Text.tsx
@@ -5,7 +5,7 @@ import Icon from '@mdi/react';
 import { mdiLoading } from '@mdi/js';
 import fonts from '../../enums/fonts';
 import Progress from '../Progress/Progress';
-import { Span } from '../../boilerplate';
+import { Span } from '../../htmlElements';
 
 /* Default Styled Text Container */
 export const TextContainer = styled(Span)`

--- a/packages/hs-react-ui/src/components/Text/Text.tsx
+++ b/packages/hs-react-ui/src/components/Text/Text.tsx
@@ -3,14 +3,12 @@ import styled, { StyledComponentBase } from 'styled-components';
 
 import Icon from '@mdi/react';
 import { mdiLoading } from '@mdi/js';
-import fonts from '../../enums/fonts';
 import Progress from '../Progress/Progress';
 import { Span } from '../../htmlElements';
 
 /* Default Styled Text Container */
 export const TextContainer = styled(Span)`
   ${({ size, color }: { size: string; color: string }) => `
-    ${fonts.body}
     font-size: ${size};
     color: ${color};
   `}

--- a/packages/hs-react-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/hs-react-ui/src/components/TextInput/TextInput.tsx
@@ -4,7 +4,7 @@ import Icon from '@mdi/react';
 import { mdiClose } from '@mdi/js';
 import fonts from '../../enums/fonts';
 import colors from '../../enums/colors';
-import { Div, Input as InputElement } from '../../boilerplate';
+import { Div, Input as InputElement } from '../../htmlElements';
 
 const Container = styled.div`
   width: 10rem;

--- a/packages/hs-react-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/hs-react-ui/src/components/TextInput/TextInput.tsx
@@ -2,30 +2,22 @@ import React, { ReactNode, SyntheticEvent } from 'react';
 import styled, { StyledComponentBase } from 'styled-components';
 import Icon from '@mdi/react';
 import { mdiClose } from '@mdi/js';
-import fonts from '../../enums/fonts';
 import colors from '../../enums/colors';
 import { Div, Input as InputElement } from '../../htmlElements';
 
-const Container = styled.div`
+const Container = styled(Div)`
   width: 10rem;
   position: relative;
   display: flex;
   flex-flow: row nowrap;
   border 2px solid ${colors.grayMedium};
   border-radius: 0.25em;
-  ${fonts.body}
-
-  *,
-  * * {
-    box-sizing: border-box;
-  }
 `;
 
 const TextInputContainer = styled(InputElement)`
   border: 0 none;
   outline: 0 none;
   height: 2em;
-  ${fonts.body}
   font-size: 1em;
   width: 0px;
   flex: 1 1 100%;

--- a/packages/hs-react-ui/src/components/TextInput/TextInput.tsx
+++ b/packages/hs-react-ui/src/components/TextInput/TextInput.tsx
@@ -4,6 +4,7 @@ import Icon from '@mdi/react';
 import { mdiClose } from '@mdi/js';
 import fonts from '../../enums/fonts';
 import colors from '../../enums/colors';
+import { Div, Input as InputElement } from '../../boilerplate';
 
 const Container = styled.div`
   width: 10rem;
@@ -20,7 +21,7 @@ const Container = styled.div`
   }
 `;
 
-const TextInputContainer = styled.input`
+const TextInputContainer = styled(InputElement)`
   border: 0 none;
   outline: 0 none;
   height: 2em;
@@ -31,7 +32,7 @@ const TextInputContainer = styled.input`
   background-color: ${colors.background};
 `;
 
-const IconContainer = styled.div`
+const IconContainer = styled(Div)`
   padding: 0.5em;
   height: 100%;
   display: flex;
@@ -40,7 +41,7 @@ const IconContainer = styled.div`
   color: ${colors.grayMedium};
 `;
 
-const ErrorContainer = styled.div`
+const ErrorContainer = styled(Div)`
   position: absolute;
   top: calc(100% + 0.25em);
   color: ${colors.destructive};

--- a/packages/hs-react-ui/src/enums/fonts.ts
+++ b/packages/hs-react-ui/src/enums/fonts.ts
@@ -1,5 +1,6 @@
 enum fonts {
-  body = "@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap'); font-family: Montserrat, Roboto, sans-serif;",
+  importFonts = `@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap');`,
+  body = `font-family: Montserrat, Roboto, sans-serif;`
 }
 
 export default fonts;

--- a/packages/hs-react-ui/src/enums/fonts.ts
+++ b/packages/hs-react-ui/src/enums/fonts.ts
@@ -1,6 +1,6 @@
 enum fonts {
-  importFonts = `@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap');`,
-  body = `font-family: Montserrat, Roboto, sans-serif;`
+  importFonts = '@import url(\'https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap\');',
+  body = 'font-family: Montserrat, Roboto, sans-serif;'
 }
 
 export default fonts;

--- a/packages/hs-react-ui/src/enums/fonts.ts
+++ b/packages/hs-react-ui/src/enums/fonts.ts
@@ -1,6 +1,6 @@
 enum fonts {
-  importFonts = '@import url(\'https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap\');',
-  body = 'font-family: Montserrat, Roboto, sans-serif;'
+  importFonts = "@import url('https://fonts.googleapis.com/css2?family=Montserrat:wght@300;500;700;900&display=swap');",
+  body = 'font-family: Montserrat, Roboto, sans-serif;',
 }
 
 export default fonts;

--- a/packages/hs-react-ui/src/htmlElements/index.tsx
+++ b/packages/hs-react-ui/src/htmlElements/index.tsx
@@ -1,7 +1,8 @@
+import { ComponentType } from 'react'
 import styled, { StyledComponent } from 'styled-components';
 import fonts from '../enums/fonts';
 
-const withGlobalStyle = (Component: StyledComponent<any, any>) => styled(Component)`
+const withGlobalStyle = (Component: StyledComponent<ComponentType, object>) => styled(Component)`
   box-sizing: border-box;
   ${process.env.NODE_ENV !== 'test' ? fonts.importFonts : ''}
   ${fonts.body}

--- a/packages/hs-react-ui/src/htmlElements/index.tsx
+++ b/packages/hs-react-ui/src/htmlElements/index.tsx
@@ -7,6 +7,8 @@ const withGlobalStyle = (Component: string & StyledComponentBase<any, {}>) => st
   ${fonts.body}
 `;
 
+// Use these elements over native styled.xx elements, as they apply
+// sensible defaults for each element. If an element doesn't exist, add it to this block
 export const Div = withGlobalStyle(styled.div``);
 export const Span = withGlobalStyle(styled.span``);
 export const Button = withGlobalStyle(styled.button``);

--- a/packages/hs-react-ui/src/htmlElements/index.tsx
+++ b/packages/hs-react-ui/src/htmlElements/index.tsx
@@ -1,7 +1,7 @@
+import styled, { StyledComponent } from 'styled-components';
 import fonts from '../enums/fonts';
-import styled from 'styled-components';
 
-const withGlobalStyle = Component => styled(Component)`
+const withGlobalStyle = (Component: StyledComponent<any, any>) => styled(Component)`
   box-sizing: border-box;
   ${fonts.body}
 `;

--- a/packages/hs-react-ui/src/htmlElements/index.tsx
+++ b/packages/hs-react-ui/src/htmlElements/index.tsx
@@ -1,8 +1,7 @@
-import { ComponentType } from 'react'
-import styled, { StyledComponent } from 'styled-components';
+import styled, { StyledComponentBase } from 'styled-components';
 import fonts from '../enums/fonts';
 
-const withGlobalStyle = (Component: StyledComponent<ComponentType, object>) => styled(Component)`
+const withGlobalStyle = (Component: string & StyledComponentBase<any, {}>) => styled(Component)`
   box-sizing: border-box;
   ${process.env.NODE_ENV !== 'test' ? fonts.importFonts : ''}
   ${fonts.body}

--- a/packages/hs-react-ui/src/htmlElements/index.tsx
+++ b/packages/hs-react-ui/src/htmlElements/index.tsx
@@ -3,6 +3,7 @@ import fonts from '../enums/fonts';
 
 const withGlobalStyle = (Component: StyledComponent<any, any>) => styled(Component)`
   box-sizing: border-box;
+  ${process.env.NODE_ENV !== 'test' ? fonts.importFonts : ''}
   ${fonts.body}
 `;
 


### PR DESCRIPTION
Devs should now use these elements via `styled(Div)` rather than `styled.div`